### PR TITLE
use modern go idioms and whitespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,5 @@ import (
 )
 
 func main() {
-
 	utils.RenderUsers()
-
 }

--- a/models/user.go
+++ b/models/user.go
@@ -11,9 +11,10 @@ type User struct {
 	Email string
 }
 
-// add new user into git config file
-func AddUsr(name string, email string) (User, error) {
+// add new user into git config file.
+func AddUsr(name, email string) (User, error) {
 	sectionName := "users." + name + ".name"
+
 	sectionEmail := "users." + name + ".email"
 	if err := exec.Command("git", "config", "--global", "--add", sectionEmail, email).Run(); err != nil {
 		return User{}, err
@@ -39,10 +40,10 @@ func GetUsr(name string) (User, error) {
 	}
 
 	email, err := exec.Command("git", "config", "--global", sectionEmail).Output()
-
 	if err != nil {
 		return User{}, err
 	}
+
 	nemail := strings.Trim(string(email), "\f\t\r\n ")
 	nname := strings.Trim(string(n), "\f\t\r\n ")
 
@@ -50,11 +51,9 @@ func GetUsr(name string) (User, error) {
 		Name:  nname,
 		Email: nemail,
 	}, nil
-
 }
 
 func SetUsr(name string) {
-
 	sectionName := "users." + name + ".name"
 	sectionEmail := "users." + name + ".email"
 
@@ -89,11 +88,10 @@ func SetUsr(name string) {
 	}
 }
 
-// get the current user on git config file
+// get the current user on git config file.
 func GetCurrentUsr() User {
-
-	//var email strings.Builder
-	//var name strings.Builder
+	// var email strings.Builder
+	// var name strings.Builder
 	name, err := exec.Command("git", "config", "--global", "user.name").Output()
 	if err != nil {
 		log.Fatal(err)
@@ -111,12 +109,10 @@ func GetCurrentUsr() User {
 		Name:  nname,
 		Email: nemail,
 	}
-
 }
 
-// delete user from git config file
-func (usr *User) DelUsr(name string, email string) {
-
+// delete user from git config file.
+func (usr *User) DelUsr(name, email string) {
 	if err := exec.Command("git", "config", "--global", "--unset-all", "users.email", usr.Email).Run(); err != nil {
 		log.Fatal(err)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,25 +15,27 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-func PrintInfo(format string, args ...interface{}) {
+func PrintInfo(format string, args ...any) {
 	fmt.Printf("\x1b[34;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 }
 
-// global .gitconfigfile path
+// global .gitconfigfile path.
 func globalConfigFile() string {
 	home, err := os.UserHomeDir()
 	CheckErr(err)
+
 	return filepath.Join(home, ".gitconfig")
 }
 
-// load config file
+// load config file.
 func loadGlobalConfigFile() *ini.File {
 	cfg, err := ini.Load(globalConfigFile())
 	CheckErr(err)
+
 	return cfg
 }
 
-// get users section keys
+// get users section keys.
 func getGlobalUsersKeys() []string {
 	file, err := os.Open(globalConfigFile())
 	CheckErr(err)
@@ -41,10 +43,12 @@ func getGlobalUsersKeys() []string {
 
 	re := regexp.MustCompile(`\[users\s+"(.*?)"\]`)
 	scanner := bufio.NewScanner(file)
+
 	var usersKeys []string
 
 	for scanner.Scan() {
 		line := scanner.Text()
+
 		match := re.FindStringSubmatch(line)
 		if len(match) > 1 {
 			usersKeys = append(usersKeys, match[1])
@@ -57,9 +61,10 @@ func getGlobalUsersKeys() []string {
 	return usersKeys
 }
 
-// prepare users section
+// prepare users section.
 func prepareUsers(usersKeys []string) []models.User {
 	var users []models.User
+
 	for _, v := range usersKeys {
 		u := "users \"" + v + "\""
 		section := loadGlobalConfigFile().Section(u)
@@ -67,6 +72,7 @@ func prepareUsers(usersKeys []string) []models.User {
 		CheckErr(err)
 		email, err := section.GetKey("email")
 		CheckErr(err)
+
 		user := models.User{
 			Name:  name.String(),
 			Email: email.String(),
@@ -77,20 +83,21 @@ func prepareUsers(usersKeys []string) []models.User {
 	return append(users, models.GetCurrentUsr())
 }
 
-// render users
+// render users.
 func RenderUsers() {
-
 	var users []string
+
 	var currUser string
+
 	for _, usr := range prepareUsers(getGlobalUsersKeys()) {
 		if usr.Name == models.GetCurrentUsr().Name && usr.Email == models.GetCurrentUsr().Email {
-
 			currUser = color.YellowString("%s <%s> *", usr.Name, usr.Email)
 			users = append(users, currUser)
 		} else {
 			users = append(users, fmt.Sprintf("%s <%s>", usr.Name, usr.Email))
 		}
 	}
+
 	slices.Reverse(users)
 	prompt := promptui.Select{
 		Label: "Select User",
@@ -98,9 +105,9 @@ func RenderUsers() {
 	}
 
 	_, result, err := prompt.Run()
-
 	if err != nil {
 		fmt.Printf("Prompt failed %v\n", err)
+
 		return
 	}
 
@@ -114,11 +121,12 @@ func RenderUsers() {
 	}
 }
 
-// handle error
+// handle error.
 func CheckErr(err error) {
 	if err == nil {
 		return
 	}
+
 	fmt.Printf("\x1b[31;1m%s\x1b[0m\n", fmt.Sprintf("error: %s", err))
 	os.Exit(1)
 }


### PR DESCRIPTION
Here are a few small changes that bring this code toward modern Go idioms and common whitespace use including punctuation for comments. All these can be easily automated with tools like golangci-lint with the --fix flag, gofmt, or gofumpt, and the new modernizer in gopls.