### PR TITLE
Add direct user switching capability

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,21 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/surbytes/gitusr/utils"
 )
 
 func main() {
+	if len(os.Args) > 2 && os.Args[1] == "switch" {
+		err := utils.SwitchUserByName(os.Args[2])
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+			os.Exit(1)
+		}
+	} else {
 
-	utils.RenderUsers()
-
+		utils.RenderUsers()
+	}
 }


### PR DESCRIPTION
I've added a SwitchUserByName function that allows users to directly switch Git profiles from the command line without using the interactive menu.
Users can now run gitusr switch profilename to quickly change their Git identity